### PR TITLE
Recent file open

### DIFF
--- a/bsnes/ui-qt/base/filebrowser.moc.hpp
+++ b/bsnes/ui-qt/base/filebrowser.moc.hpp
@@ -11,6 +11,8 @@ public:
   enum CartridgeMode { LoadDirect, LoadBase, LoadSlot1, LoadSlot2 } cartridgeMode;
   void loadCartridge(CartridgeMode, signed = -1);
 
+  void onAcceptCartridge(const string&);
+
   FileBrowser();
 
 private slots:
@@ -28,7 +30,6 @@ private:
 
   string resolveFilename(const string&);
   void onChangeCartridge(const string&);
-  void onAcceptCartridge(const string&);
 
   void acceptNormal(const string &filename);
   void acceptBsx(const string &filename);

--- a/bsnes/ui-qt/base/main.cpp
+++ b/bsnes/ui-qt/base/main.cpp
@@ -749,6 +749,7 @@ void CanvasObject::dropEvent(QDropEvent *event) {
   if(event->mimeData()->hasUrls()) {
     QList<QUrl> list = event->mimeData()->urls();
     if(list.count() == 1) cartridge.loadNormal(list.at(0).toLocalFile().toUtf8().constData());
+    mainWindow->updateRecentFiles();
   }
 }
 

--- a/bsnes/ui-qt/base/main.cpp
+++ b/bsnes/ui-qt/base/main.cpp
@@ -18,6 +18,7 @@ MainWindow::MainWindow() {
   system = menuBar->addMenu("&System");
 
   system_load = system->addAction("Load &Cartridge ...");
+  system_load->setShortcut(QKeySequence("Ctrl+C"));
 
   system_loadSpecial = system->addMenu("Load &Special");
 
@@ -34,6 +35,7 @@ MainWindow::MainWindow() {
   system->addAction(system_power = new CheckAction("&Power", 0));
 
   system_reset = system->addAction("&Reset");
+  system_reset->setShortcut(QKeySequence("Ctrl+R"));
 
   system->addSeparator();
 
@@ -60,6 +62,8 @@ MainWindow::MainWindow() {
 
   system_exit = system->addAction("E&xit");
   system_exit->setMenuRole(QAction::QuitRole);
+  system_exit->setShortcut(Qt::Key_Escape);
+  system_exit->setShortcutContext( Qt::ApplicationShortcut );
 
   settings = menuBar->addMenu("S&ettings");
 
@@ -176,12 +180,14 @@ MainWindow::MainWindow() {
   tools_cheatFinder = tools->addAction("Cheat &Finder ...");
 
   tools_stateManager = tools->addAction("&State Manager ...");
+  tools_stateManager->setShortcut(QKeySequence("Ctrl+M"));
 
   tools_effectToggle = tools->addAction("Effect &Toggle ...");
   if(!SNES::PPU::SupportsLayerEnable && !SNES::DSP::SupportsChannelEnable)
     tools_effectToggle->setVisible(false);
 
   tools_debugger = tools->addAction("&Debugger ...");
+  tools_debugger->setShortcut(QKeySequence("Ctrl+D"));
   #if !defined(DEBUGGER)
   tools_debugger->setVisible(false);
   #endif

--- a/bsnes/ui-qt/base/main.moc.hpp
+++ b/bsnes/ui-qt/base/main.moc.hpp
@@ -13,15 +13,31 @@ public:
   void paintEvent(QPaintEvent*);
 };
 
+class RecentFileAction : public QAction {
+  Q_OBJECT
+public:
+  RecentFileAction(const QString & text, QObject * parent, int id);
+  int id;
+public slots:
+  void load();
+};
+
 class MainWindow : public Window {
   Q_OBJECT
 
 public:
+  void updateRecentFiles();
   QMenuBar *menuBar;
   QStatusBar *statusBar;
   QVBoxLayout *layout;
   QMenu *system;
     QAction *system_load;
+    QMenu *system_load_recent;
+      struct RecentFiles
+      {
+        RecentFileAction *actions[Configuration::NUMFILES];
+        int active_slots;
+      } recentFiles;
     QMenu *system_loadSpecial;
       QAction *system_loadSpecial_bsxSlotted;
       QAction *system_loadSpecial_bsx;

--- a/bsnes/ui-qt/config.cpp
+++ b/bsnes/ui-qt/config.cpp
@@ -137,4 +137,11 @@ Configuration::Configuration() {
   attach(geometry.oamViewer        = "", "geometry.oamViewer");
   attach(geometry.cgramViewer      = "", "geometry.cgramViewer");
   attach(geometry.debuggerOptions  = "", "geometry.debuggerOptions");
+
+  for (int i=0; i < NUMFILES; i++)
+  {
+    char str[25];
+    sprintf(str, "recentFile%d", i);
+    attach(recentFiles[i] = "", str);
+  }
 }

--- a/bsnes/ui-qt/config.hpp
+++ b/bsnes/ui-qt/config.hpp
@@ -102,6 +102,9 @@ public:
     string debuggerOptions;
   } geometry;
 
+  static const int NUMFILES=10;
+  string recentFiles[NUMFILES];
+
   bool load(const char *filename);
   Configuration();
 };

--- a/bsnes/ui-qt/debugger/debugger.cpp
+++ b/bsnes/ui-qt/debugger/debugger.cpp
@@ -34,9 +34,13 @@ Debugger::Debugger() {
 
   menu_tools = menu->addMenu("Tools");
   menu_tools_disassembler = menu_tools->addAction("Disassembler ...");
+  //menu_tools_disassembler->setShortcut(QKeySequence("Ctrl+D"));
   menu_tools_breakpoint = menu_tools->addAction("Breakpoint Editor ...");
+  menu_tools_breakpoint->setShortcut(QKeySequence("Ctrl+B"));
   menu_tools_memory = menu_tools->addAction("Memory Editor ...");
+  menu_tools_memory->setShortcut(QKeySequence("Ctrl+M"));
   menu_tools_propertiesViewer = menu_tools->addAction("Properties Viewer ...");
+  menu_tools_propertiesViewer->setShortcut(QKeySequence("Ctrl+P"));
 
   menu_ppu = menu->addMenu("S-PPU");
   menu_ppu_vramViewer = menu_ppu->addAction("Video RAM Viewer ...");
@@ -64,18 +68,22 @@ Debugger::Debugger() {
   controlLayout->addLayout(commandLayout);
 
   runBreak = new QPushButton("Break");
+  runBreak->setShortcut(Qt::Key_B);
   commandLayout->addWidget(runBreak);
   commandLayout->addSpacing(Style::WidgetSpacing);
 
   stepInstruction = new QPushButton("Step");
+  stepInstruction->setShortcut(Qt::Key_Space);
   commandLayout->addWidget(stepInstruction);
 
   controlLayout->addSpacing(Style::WidgetSpacing);
 
   stepCPU = new QCheckBox("Step S-CPU");
+  stepCPU->setShortcut(Qt::Key_C);
   controlLayout->addWidget(stepCPU);
 
   stepSMP = new QCheckBox("Step S-SMP");
+  stepSMP->setShortcut(Qt::Key_S);
   controlLayout->addWidget(stepSMP);
 
   traceCPU = new QCheckBox("Trace S-CPU opcodes");
@@ -153,6 +161,7 @@ void Debugger::modifySystemState(unsigned state) {
 
 void Debugger::synchronize() {
   runBreak->setText(application.debug ? "Run" : "Break");
+  application.debug ? runBreak->setShortcut(Qt::Key_R) : runBreak->setShortcut(Qt::Key_B);
   stepInstruction->setEnabled(SNES::cartridge.loaded() && application.debug && (stepCPU->isChecked() || stepSMP->isChecked()));
   SNES::debugger.step_cpu = application.debug && stepCPU->isChecked();
   SNES::debugger.step_smp = application.debug && stepSMP->isChecked();


### PR DESCRIPTION
This is a useful feature to have. It adds an "Open Recent..." File submenu for loading files you've loaded in the past. 'nuff said (not really) .. I didn't test the feature with BSX/sufami turbo (I've never messed with that stuff), but it should work.. I opened a function that is used to load all types of cartridges based on file extension.. but I tested it with normal carts only. Seems to work. Be careful, could be broken. Try it out, you will love it :)

Note: I had to combine a commit from my previous pull request (Mandatory) for keyboard menu shortcuts, because they modify the same file.. Does that present problems? I am new to pull requests.
